### PR TITLE
Update kpi.js - Laiko juostoje, datos turi būti atvaizduojamos vienodais intervalais

### DIFF
--- a/prototype/static/js/kpi.js
+++ b/prototype/static/js/kpi.js
@@ -1,8 +1,10 @@
-(function (d3) {
+(function (d3, c3) {
     d3.json("/topic/balsavimas-internetu/kpi/", function(jsonData) {
-        var i = 1;
-        var yLabel;
-        var dataToChart = [], dataNames = [], yAxe = [], dataAndX = [], chartType = [];
+        var i = 1; 
+        var yLabel, eventsLevel, eventsLevelSameDay, tempDate, tempLevel;
+        var dataMin = Number.MAX_VALUE, dataMax = Number.MIN_VALUE;
+        var yearMin = Number.MAX_VALUE, yearMax = Number.MIN_VALUE;
+        var dataToChart = [], dataNames = [], dataAndX = [], chartType = [], dataHide = [];
 
         jsonData.indicators.forEach(function(jsonEachData) {
             var itemName = "data" + i;
@@ -11,14 +13,19 @@
             dataAndX[itemName] = date[0];
             dataNames[itemName] = jsonEachData.title;
             chartType[itemName] = "line";
-            yAxe[itemName] = 'y';
             yLabel = jsonEachData.ylabel;
             jsonEachData.data.forEach(function(dateAndMark) {
                 dateAndMark.forEach(function(dateOrMark, j) {
-                    if (j % 2 == 0) 
-                        date.push(dateOrMark)
-                    else 
+                    if (j % 2 == 0) {
+                        date.push(dateOrMark);
+                        var year = new Date(dateOrMark);
+                        yearMin = Math.min(yearMin, year.getFullYear());
+                        yearMax = Math.max(yearMax, year.getFullYear());
+                    } else {
                         mark.push(dateOrMark);
+                        dataMin = Math.min(dataMin, dateOrMark);
+                        dataMax = Math.max(dataMax, dateOrMark);
+                    }   
                 });
             });
             dataToChart.push(date);
@@ -26,40 +33,47 @@
             i++;
         });
 
+        eventsLevel = dataMin - (dataMax - dataMin) * 0.1;
+        eventsLevelSameDay = (dataMax - dataMin) * 0.02;
+        yearMax = yearMax - yearMin;
+
         jsonData.events.forEach(function(jsonEachData) {
             var itemName = "data" + i;
             var date = ["x"+i];
             var mark = [itemName];
-            var temporarMark; 
             dataAndX[itemName] = date[0];
             dataNames[itemName] = jsonEachData.title;
             chartType[itemName] = "scatter";
-            yAxe[itemName] = 'y2';
             date.push(jsonEachData.date);
-            temporarMark = jsonEachData.position;
-            if (temporarMark == null) 
-                temporarMark = 0;
-            mark.push(temporarMark);
+            if (tempDate == jsonEachData.date) {
+                tempLevel += eventsLevelSameDay;
+            } else {
+                tempLevel = eventsLevel;
+            }
+            tempDate = jsonEachData.date;
+            mark.push(tempLevel);
             dataToChart.push(date);
             dataToChart.push(mark);
+            dataHide.push(itemName);
             i++;
         });
 
-        // window.alert(dataToChart);
-        var chart = c3.generate( {	
+        c3.generate( {
             data: {
                 xs: dataAndX,
                 columns: dataToChart,
                 names: dataNames,
-                types: chartType,
-                axes: yAxe,
+                types: chartType
+            },
+            legend: {
+                hide: dataHide
             },
             axis: {
                 x: {
                     type: 'timeseries',
                     tick: {
-                        rotate: 45,
-                        format: '%Y-%m-%d'
+                        count: yearMax,
+                        format: '%Y'
                     }
                 },
                 y: {
@@ -67,11 +81,8 @@
                         text: yLabel,
                         position: 'outer-middle'
                     }
-                },
-                y2: {
-                    show: true
                 }
             }
-        });	
+        });
     });
-}(d3));
+}(d3, c3));  //eslint-disable-line no-undef


### PR DESCRIPTION
"Laiko juostoje, datos turi būti atvaizduojamos vienodais intervalais, intervalo dydis priklauso nuo grafike atvaizduotą laikotarpį. Iš esmės, turėtų būti atvaizduota apie 10 antraščių."

Metai rodomi ne kiekviename žingsnyje. Kodėl - nežinau. Jeigu tai nėra problema, tada viskas gerai, o jeigu yra - tada reikės rašyti kurėjui ir klausti kame reikalas - ar tai klaida ar taip ir turi būti?

Dėl atnaujinimo iš upstreamo padariau viską pagal instrukciją bet kažkodėl po to mano fork'e kpi.js tapo su senu kodu...
